### PR TITLE
Set python interpreter path for molecule

### DIFF
--- a/.github/workflows/ansible-collection.yml
+++ b/.github/workflows/ansible-collection.yml
@@ -31,8 +31,5 @@ jobs:
           # prepare k8s environment
           kubectl cluster-info
           kubectl create namespace mytest
-          # set python interpreter path
-          export ANSIBLE_PYTHON_INTERPRETER=$(which python)
-          echo ANSIBLE_PYTHON_INTERPRETER=$ANSIBLE_PYTHON_INTERPRETER
           # test
-          molecule test
+          make test

--- a/.github/workflows/ansible-collection.yml
+++ b/.github/workflows/ansible-collection.yml
@@ -7,6 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         #python-version: [3.6, 3.7, 3.8, 3.9]
         python-version: [3.8]
@@ -19,6 +20,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          echo PATH=$PATH
+          echo "Python path: $(which python)"
           python -m pip install --upgrade pip setuptools
           pip install -r requirements.in
           pip list
@@ -28,5 +31,8 @@ jobs:
           # prepare k8s environment
           kubectl cluster-info
           kubectl create namespace mytest
+          # set python interpreter path
+          export ANSIBLE_PYTHON_INTERPRETER=$(which python)
+          echo ANSIBLE_PYTHON_INTERPRETER=$ANSIBLE_PYTHON_INTERPRETER
           # test
           molecule test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+PYTHON ?= $(shell command -v python3 python|head -n1)
+
+.PHONY: test
+
+test:
+	ANSIBLE_PYTHON_INTERPRETER=$(PYTHON) molecule test

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ pip3 install --upgrade pip setuptools pip-tools
 
 pip install -r requirements.txt
 ```
-2. Run molecule
+2. Run molecule via make to set correct python interpreter
 
 ```
-molecule test
+make test
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ molecule test
 
 ## Development
 
-. Updating python dependencies:
+1. Updating python dependencies:
 
 ```
 source bin/activate

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,10 +8,10 @@ driver:
     managed: false
     ansible_connection_options:
       ansible_connection: local
-      # set interpreter path to env variable set in GitHub workflow
+      # set python interpreter path to venv or GitHub tools
+      # so modules installed via pip are located properly
+      # The ANSIBLE_PYTHON_INTERPRETER env variable is set in the Makefile
       ansible_python_interpreter: ${ANSIBLE_PYTHON_INTERPRETER}
-      # for local development in a venv
-      #ansible_python_interpreter: ${MOLECULE_PROJECT_DIRECTORY}/bin/python
 platforms:
   - name: localhost
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,6 +8,10 @@ driver:
     managed: false
     ansible_connection_options:
       ansible_connection: local
+      # set interpreter path to env variable set in GitHub workflow
+      ansible_python_interpreter: ${ANSIBLE_PYTHON_INTERPRETER}
+      # for local development in a venv
+      #ansible_python_interpreter: ${MOLECULE_PROJECT_DIRECTORY}/bin/python
 platforms:
   - name: localhost
 provisioner:


### PR DESCRIPTION
Set the python interpreter path to the virtual environment or the GitHub tools python so modules installed via pip are located properly during molecule runs.

resolves #1 